### PR TITLE
BISM Normalizer extension for VS 2019

### DIFF
--- a/BismNormalizer/BismNormalizer/source.extension.vsixmanifest
+++ b/BismNormalizer/BismNormalizer/source.extension.vsixmanifest
@@ -10,8 +10,9 @@
         <PreviewImage>Resources\BismNormalizerLogoText.png</PreviewImage>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
-        <InstallationTarget Version="[14.0,15.0]" Id="Microsoft.VisualStudio.IntegratedShell" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,16.1]" />
+        <InstallationTarget Version="[14.0,16.1]" Id="Microsoft.VisualStudio.IntegratedShell" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[14.0,16.1]" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -22,6 +23,6 @@
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Newtonsoft.Json.dll" AssemblyName="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[14.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[14.0,17.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Updated the vsixmanifest file to include VS 2019 (version 16.1)