### PR TITLE
Added "trim object names" rule

### DIFF
--- a/BestPracticeRules/BPARules.json
+++ b/BestPracticeRules/BPARules.json
@@ -670,5 +670,15 @@
     "Scope": "DataColumn, CalculatedColumn, CalculatedTableColumn",
     "Expression": "Name.ToUpper().Contains(\"MONTH\")\r\nand\r\n! Name.ToUpper().Contains(\"MONTHS\") \r\nand \r\n\n\nDataType == DataType.String \r\nand \r\nSortByColumn == null",
     "CompatibilityLevel": 1200
+  },
+  {
+    "ID": "TRIM_OBJECT_NAMES",
+    "Name": "[Naming Conventions] Trim object names",
+    "Category": "Naming Conventions",
+    "Description": "Unintentionally leaving a trailing space in an object name is a common occurrence when copying/duplicating objects in Tabular Editor.",
+    "Severity": 1,
+    "Scope": "Model, Table, Measure, Hierarchy, Level, Perspective, Partition, ProviderDataSource, DataColumn, CalculatedColumn, CalculatedTable, CalculatedTableColumn, StructuredDataSource, NamedExpression, ModelRole, CalculationGroup, CalculationItem",
+    "Expression": "Name.StartsWith(\" \") or Name.EndsWith(\" \")",
+    "CompatibilityLevel": 1200
   }
 ]


### PR DESCRIPTION
Add a rule that checks if any objects have leading or trailing spaces in their names, as this is most likely unintentional (i.e. when copying an object, Tabular Editor appends " 1" to the name, and deleting just the "1" leaves a trailing space in the name).

CC @m-kovalsky 