### PR TITLE
Change categorization for RELATIONSHIP_COLUMNS_SHOULD_BE_OF_INTEGER_DATA_TYPE

### DIFF
--- a/BestPracticeRules/BPARules.json
+++ b/BestPracticeRules/BPARules.json
@@ -633,8 +633,8 @@
   },
   {
     "ID": "RELATIONSHIP_COLUMNS_SHOULD_BE_OF_INTEGER_DATA_TYPE",
-    "Name": "[Formatting] Relationship columns should be of integer data type",
-    "Category": "Formatting",
+    "Name": "[Performance] Relationship columns should be of integer data type",
+    "Category": "Performance",
     "Description": "It is a best practice for relationship columns to be of integer data type. This applies not only to data warehousing but data modeling as well.",
     "Severity": 1,
     "Scope": "DataColumn, CalculatedColumn, CalculatedTableColumn",


### PR DESCRIPTION
Rule RELATIONSHIP_COLUMNS_SHOULD_BE_OF_INTEGER_DATA_TYPE is better categorized as Performance. This has proven to be as significant improvement in Performance for tabular models.