### PR TITLE
Add rule for excessive number of measures in model

### DIFF
--- a/BestPracticeRules/BPARules.json
+++ b/BestPracticeRules/BPARules.json
@@ -539,6 +539,16 @@
     "CompatibilityLevel": 1200
   },
   {
+    "ID": "REDUCE_NUMBER_OF_MEASURES",
+    "Name": "[Maintenance] Reduce number of measures",
+    "Category": "Maintenance",
+    "Description": "If you have an excessive number of measures, you should attempt to reduce the number of measures by utilizing calculation groups or reviewing your model design.\r\nIf this is not possible, you should disable all BPA rules that iterate over the AllMeasures collection to avoid Tabular Editor freezing and becoming unresponsive.",
+    "Severity": 1,
+    "Scope": "Model",
+    "Expression": "Model.AllMeasures.Count() > 500",
+    "CompatibilityLevel": 1200
+  },
+  {
     "ID": "PARTITION_NAME_SHOULD_MATCH_TABLE_NAME_FOR_SINGLE_PARTITION_TABLES",
     "Name": "[Naming Conventions] Partition name should match table name for single partition tables",
     "Category": "Naming Conventions",
@@ -722,16 +732,6 @@
     "Severity": 2,
     "Scope": "DataColumn, CalculatedColumn, CalculatedTableColumn",
     "Expression": "Name.ToUpper().Contains(\"MONTH\")\r\nand\r\n! Name.ToUpper().Contains(\"MONTHS\") \r\nand \r\n\n\nDataType == DataType.String \r\nand \r\nSortByColumn == null",
-    "CompatibilityLevel": 1200
-  },
-  {
-    "ID": "REDUCE_NUMBER_OF_MEASURES",
-    "Name": "[Maintenance] Reduce number of measures",
-    "Category": "Maintenance",
-    "Description": "If you have an excessive number of measures, you should attempt to reduce the number of measures by utilizing calculation groups or reviewing your model design.\r\nIf this is not possible, you should disable all BPA rules that iterate over the AllMeasures collection to avoid Tabular Editor freezing and becoming unresponsive.",
-    "Severity": 1,
-    "Scope": "Model",
-    "Expression": "Model.AllMeasures.Count() > 500",
     "CompatibilityLevel": 1200
   }
 ]

--- a/BestPracticeRules/BPARules.json
+++ b/BestPracticeRules/BPARules.json
@@ -723,5 +723,15 @@
     "Scope": "DataColumn, CalculatedColumn, CalculatedTableColumn",
     "Expression": "Name.ToUpper().Contains(\"MONTH\")\r\nand\r\n! Name.ToUpper().Contains(\"MONTHS\") \r\nand \r\n\n\nDataType == DataType.String \r\nand \r\nSortByColumn == null",
     "CompatibilityLevel": 1200
+  },
+  {
+    "ID": "REDUCE_NUMBER_OF_MEASURES",
+    "Name": "[Maintenance] Reduce number of measures",
+    "Category": "Maintenance",
+    "Description": "If you have an excessive number of measures, you should attempt to reduce the number of measures by utilizing calculation groups or reviewing your model design.\r\nIf this is not possible, you should disable all BPA rules that iterate over the AllMeasures collection to avoid Tabular Editor freezing and becoming unresponsive.",
+    "Severity": 1,
+    "Scope": "Model",
+    "Expression": "Model.AllMeasures.Count() > 500",
+    "CompatibilityLevel": 1200
   }
 ]

--- a/BestPracticeRules/Italian/BPARules.json
+++ b/BestPracticeRules/Italian/BPARules.json
@@ -540,6 +540,16 @@
     "CompatibilityLevel": 1200
   },
   {
+    "ID": "REDUCE_NUMBER_OF_MEASURES",
+    "Name": "[Manutenzione] Ridurre il numero di misure",
+    "Category": "Manutenzione",
+    "Description": "Se disponi di un numero eccessivo di misure, dovresti tentare di ridurre il numero di misure utilizzando gruppi di calcolo o rivedendo la progettazione del modello.\r\nSe ciò non è possibile, dovresti disabilitare tutte le regole BPA che eseguono l'iterazione sulla raccolta AllMeasures per evitare che l'editor tabulare si blocchi e non risponda.",
+    "Severity": 1,
+    "Scope": "Model",
+    "Expression": "Model.AllMeasures.Count() > 500",
+    "CompatibilityLevel": 1200
+  },
+  {
     "ID": "PARTITION_NAME_SHOULD_MATCH_TABLE_NAME_FOR_SINGLE_PARTITION_TABLES",
     "Name": "[Naming Conventions] Il nome della partizione deve corrispondere al nome della tabella per le singole tabelle delle partizioni",
     "Category": "Naming Conventions",

--- a/BestPracticeRules/Japanese/BPARules.json
+++ b/BestPracticeRules/Japanese/BPARules.json
@@ -540,6 +540,16 @@
     "CompatibilityLevel": 1200
   },
   {
+    "ID": "REDUCE_NUMBER_OF_MEASURES",
+    "Name": "[メンテナンス] 小節数を減らす",
+    "Category": "メンテナンス",
+    "Description": "メジャーの数が多すぎる場合は、計算グループを利用するか、モデル設計を見直してメジャーの数を減らすようにしてください。\r\nそれが不可能な場合は、AllMeasures コレクションを反復処理するすべての BPA ルールを無効にする必要があります。 表形式エディタがフリーズして応答しなくなることを回避します。",
+    "Severity": 1,
+    "Scope": "Model",
+    "Expression": "Model.AllMeasures.Count() > 500",
+    "CompatibilityLevel": 1200
+  },
+  {
     "ID": "PARTITION_NAME_SHOULD_MATCH_TABLE_NAME_FOR_SINGLE_PARTITION_TABLES",
     "Name": "[命名規則]パーティション名は、単一パーティションテーブルのテーブル名と一致する必要がある",
     "Category": "命名規則",

--- a/BestPracticeRules/Spanish/BPARules.json
+++ b/BestPracticeRules/Spanish/BPARules.json
@@ -540,6 +540,16 @@
     "CompatibilityLevel": 1200
   },
   {
+    "ID": "REDUCE_NUMBER_OF_MEASURES",
+    "Name": "[Mantenimiento] Reducir el número de medidas.",
+    "Category": "Mantenimiento",
+    "Description": "Si tiene una cantidad excesiva de medidas, debe intentar reducir la cantidad de medidas utilizando grupos de cálculo o revisando el diseño de su modelo.\r\nSi esto no es posible, debe desactivar todas las reglas de BPA que se repiten sobre la colección Todas las medidas para Evite que Tabular Editor se congele y deje de responder.",
+    "Severity": 1,
+    "Scope": "Model",
+    "Expression": "Model.AllMeasures.Count() > 500",
+    "CompatibilityLevel": 1200
+  },
+  {
     "ID": "PARTITION_NAME_SHOULD_MATCH_TABLE_NAME_FOR_SINGLE_PARTITION_TABLES",
     "Name": "[Convenciones de Nombres] El nombre de la partición debe coincidir el nombre de la tabla para tablas de partición única",
     "Category": "Convenciones de Nombres",


### PR DESCRIPTION
I believe a measure should not have more than a few hundred measures.
More are typically a sign of poor model design or not using modern features such as calculation groups.
This rule highlights if a model has more than 500 measures.
If  there is a good reason for this, if prompts the user to disable all BPA rules that iterate over the Model.AllMeasures collection as we have seen users TE becoming unresponsive if using these rules with a really big quantity measures.

@m-kovalsky
