### PR TITLE
BPA Rule Updates

### DIFF
--- a/BestPracticeRules/BPARules.json
+++ b/BestPracticeRules/BPARules.json
@@ -440,7 +440,7 @@
     "Severity": 3,
     "Scope": "DataColumn, CalculatedColumn, CalculatedTableColumn",
     "Expression": "IsAvailableInMDX = false\r\n\r\nand\r\n(\r\nUsedInSortBy.Any()\r\nor\r\nUsedInHierarchies.Any()\r\nor\r\nUsedInVariations.Any()\r\nor\r\nSortByColumn != null\r\n)",
-	"FixExpression": "IsAvailableInMDX = true",
+    "FixExpression": "IsAvailableInMDX = true",
     "CompatibilityLevel": 1200
   },
   {
@@ -648,7 +648,7 @@
     "Category": "Formatting",
     "Severity": 2,
     "Scope": "Measure",
-    "Expression": "not FormatString.Contains(\"$\") and not FormatString.Contains(\"%\") and not (FormatString = \"#,0\" or FormatString = \"#,0.0\")",
+    "Expression": "(DataType = \"Int64\" or DataType = \"Decimal\" or DataType = \"Double\") and not FormatString.Contains(\"$\") and not FormatString.Contains(\"%\") and not (FormatString = \"#,0\" or FormatString = \"#,0.0\")",
     "FixExpression": "FormatString = \"#,0\"",
     "CompatibilityLevel": 1200
   },

--- a/BestPracticeRules/BPARules.json
+++ b/BestPracticeRules/BPARules.json
@@ -593,7 +593,7 @@
     "ID": "DATECOLUMN_FORMATSTRING",
     "Name": "[Formatting] Provide format string for \"Date\" columns",
     "Category": "Formatting",
-    "Description": "Columns of type \"DateTime\" that have \"Month\" in their names should be formatted as \"mm/dd/yyyy\".",
+    "Description": "Columns of type \"DateTime\" that have \"Date\" in their names should be formatted as \"mm/dd/yyyy\".",
     "Severity": 1,
     "Scope": "DataColumn, CalculatedColumn, CalculatedTableColumn",
     "Expression": "Name.IndexOf(\"Date\", \"OrdinalIgnoreCase\") >= 0 \r\nand \r\nDataType = \"DateTime\" \r\nand \r\nFormatString <> \"mm/dd/yyyy\"",


### PR DESCRIPTION
I noticed the INTEGER_FORMATTING rule was falsely identifying Date-based DAX measures against this rule.

Also description for Provide format string for "Date" and "Month" column rules had the same description. I fixed the description to reference the correct name.