### PR TITLE
fixed a bug where items with names containing unsupported characters …

### DIFF
--- a/pbidevmode/fabricps-pbip/FabricPS-PBIP.psm1
+++ b/pbidevmode/fabricps-pbip/FabricPS-PBIP.psm1
@@ -515,7 +515,7 @@ Function Export-FabricItems {
 
                     $bytes = [Convert]::FromBase64String($part.payload)
 
-                    Set-Content $outputFilePath $bytes -AsByteStream                
+                    Set-Content -LiteralPath $outputFilePath $bytes -AsByteStream
                 }
 
                 @{


### PR DESCRIPTION
…caused the conversion of bytestream data into output files to fail.