### PR TITLE
FabricsPS-PBIP: handle non text parameters in Set-SemanticModelParameters

### DIFF
--- a/pbidevmode/fabricps-pbip/FabricPS-PBIP.psm1
+++ b/pbidevmode/fabricps-pbip/FabricPS-PBIP.psm1
@@ -1155,7 +1155,7 @@ Function Set-SemanticModelParameters {
         else
         {
             Write-Host "Changing model expression '$parameterName'"
-            $modelExpression.Expression = $modelExpression.Expression -replace '(^"?)(.*?)("?)(\smeta)', "`$1$parameterValue`$3$4"
+            $modelExpression.Expression = $modelExpression.Expression -replace '(^"?)(.*?)("?)(\smeta)', "`$1$parameterValue`$3`$4"
             $changedFlag = $true
         }
     }

--- a/pbidevmode/fabricps-pbip/FabricPS-PBIP.psm1
+++ b/pbidevmode/fabricps-pbip/FabricPS-PBIP.psm1
@@ -1155,7 +1155,7 @@ Function Set-SemanticModelParameters {
         else
         {
             Write-Host "Changing model expression '$parameterName'"
-            $modelExpression.Expression = $modelExpression.Expression -replace """?(.*)""? meta","""$parameterValue"" meta"
+            $modelExpression.Expression = $modelExpression.Expression -replace '(^"?)(.*?)("?)(\smeta)', "`$1$parameterValue`$3$4"
             $changedFlag = $true
         }
     }


### PR DESCRIPTION
handle non text parameters in Set-SemanticModelParameters function by only keeping the double quotes when they are already there.