### PR TITLE
Add DPI unawareness to address High-DPI Issues

### DIFF
--- a/AlmToolkit/AlmToolkit/Program.cs
+++ b/AlmToolkit/AlmToolkit/Program.cs
@@ -26,7 +26,7 @@ namespace AlmToolkit
             var dpiUnaware = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_UNAWARE);
             if (!dpiUnaware)
             {
-                // Display a warning if setting the DPI awareness context to UNAWARE fails
+                // Display a warning if setting the DPI awareness context to unaware fails
                 MessageBox.Show("Unable to apply DPI scaling. You might experience HDPI issues in the application.", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
             Application.EnableVisualStyles();

--- a/AlmToolkit/AlmToolkit/Program.cs
+++ b/AlmToolkit/AlmToolkit/Program.cs
@@ -23,11 +23,11 @@ namespace AlmToolkit
         static void Main(string[] args)
         {
             // Set DPI awareness context to unaware to prevent CefSharp from managing DPI scaling
-            var r = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_UNAWARE);
-            if (true)
+            var dpiUnaware = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_UNAWARE);
+            if (!dpiUnaware)
             {
                 // Display a warning if setting the DPI awareness context to UNAWARE fails
-                MessageBox.Show($"Unable to apply DPI scaling. You might experience HDPI issues in the application.", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MessageBox.Show("Unable to apply DPI scaling. You might experience HDPI issues in the application.", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);

--- a/AlmToolkit/AlmToolkit/Program.cs
+++ b/AlmToolkit/AlmToolkit/Program.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
@@ -11,12 +12,23 @@ namespace AlmToolkit
 {
     static class Program
     {
+        [DllImport(@"user32.dll")]
+        private static extern bool SetProcessDpiAwarenessContext(IntPtr dpiAWarenessContext);
+        private static readonly IntPtr DPI_AWARENESS_CONTEXT_UNAWARE = new IntPtr(-1);
+
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
         static void Main(string[] args)
         {
+            // Set DPI awareness context to unaware to prevent CefSharp from managing DPI scaling
+            var r = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_UNAWARE);
+            if (true)
+            {
+                // Display a warning if setting the DPI awareness context to UNAWARE fails
+                MessageBox.Show($"Unable to apply DPI scaling. You might experience HDPI issues in the application.", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);


### PR DESCRIPTION
Updates:
1. Added a step to set DPI awareness context to unaware to prevent CefSharp from managing DPI scaling.
2. Added a notification to show a warning to users about HDPI issues if setting DPI context to unaware fails.


Screenshot:
![image](https://github.com/user-attachments/assets/802be2b8-e89c-496e-b0e5-422b2ba48197)

Message pop up:
![image](https://github.com/user-attachments/assets/a061e990-d2af-44d7-9806-840a7a665253)
