### PR TITLE
Change path trim based on running platform.

### DIFF
--- a/pbidevmode/fabricps-pbip/FabricPS-PBIP.psd1
+++ b/pbidevmode/fabricps-pbip/FabricPS-PBIP.psd1
@@ -5,7 +5,7 @@
 RootModule = 'FabricPS-PBIP.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1'
+ModuleVersion = '0.2'
 
 # Supported PSEditions
 CompatiblePSEditions = @("Core")

--- a/pbidevmode/fabricps-pbip/FabricPS-PBIP.psm1
+++ b/pbidevmode/fabricps-pbip/FabricPS-PBIP.psm1
@@ -753,7 +753,15 @@ Function Import-FabricItems {
                 }
             }
 
-            $partPath = $filePath.Replace($itemPathAbs, "").TrimStart("\").Replace("\", "/")
+            $os = uname -s
+
+            if ($os -eq "Darwin" || $os -eq "Linux") {
+                $partPath = $filePath.Replace($itemPathAbs, "").TrimStart("/").Replace("\", "/")
+            }
+            else {
+                $partPath = $filePath.Replace($itemPathAbs, "").TrimStart("\").Replace("\", "/")
+            }
+            
 
             $fileEncodedContent = ($fileContent) ? [Convert]::ToBase64String($fileContent) : ""
             


### PR DESCRIPTION
This small change allows pbip publishing to function on unix systems and windows alike without editing the source every time.