### PR TITLE
Removed the two hidden tab characters in the foreach loops

### DIFF
--- a/pbidevmode/sample-ado-pipelines/ContinuousIntegration-Rules.yml
+++ b/pbidevmode/sample-ado-pipelines/ContinuousIntegration-Rules.yml
@@ -49,7 +49,7 @@ stages:
               $itemsFolders = Get-ChildItem  -Path $path -recurse -include ("*.pbidataset", "*.pbism")
 
               foreach($itemFolder in $itemsFolders)
-              {	
+              {
                   $itemPath = "$($itemFolder.Directory.FullName)\definition"
 
                   if (!(Test-Path $itemPath))
@@ -113,7 +113,7 @@ stages:
                   $itemsFolders = Get-ChildItem  -Path $path -recurse -include *.pbir
 
                   foreach($itemFolder in $itemsFolders)
-                  {	
+                  {
                       $itemPath = $itemFolder.Directory.FullName
                       
                       Write-Host "##[group]Running rules for: '$itemPath'"


### PR DESCRIPTION
I have removed the two hidden tab characters in the foreach loops. Which would cause a problem for anybody looking to convert the code for use in classic pipelines.