### PR TITLE
Updated PROVIDE_FORMAT_STRING_FOR_MEASURES rule

### DIFF
--- a/BestPracticeRules/BPARules.json
+++ b/BestPracticeRules/BPARules.json
@@ -615,10 +615,10 @@
     "ID": "PROVIDE_FORMAT_STRING_FOR_MEASURES",
     "Name": "[Formatting] Provide format string for measures",
     "Category": "Formatting",
-    "Description": "Visible measures should have their format string property assigned",
+    "Description": "Visible not string measures should have their format string property assigned",
     "Severity": 3,
     "Scope": "Measure",
-    "Expression": "not IsHidden \r\nand not Table.IsHidden \r\nand string.IsNullOrWhitespace(FormatString)",
+    "Expression": "not IsHidden \r\nand not Table.IsHidden \r\nand string.IsNullOrWhitespace(FormatString)\r\nand DataType <> \"String\"",
     "CompatibilityLevel": 1200
   },
   {


### PR DESCRIPTION
Updated PROVIDE_FORMAT_STRING_FOR_MEASURES rule to only check for not string measures. It's not logical to check for string format for measures that are strings.  e.g. A measure like IF ( condition, "Text", "Different text" ) should not need a format string.