### PR TITLE
Fix: Strip leading `/` when creating item part paths on Unix-based systems

### DIFF
--- a/pbidevmode/fabricps-pbip/FabricPS-PBIP.psm1
+++ b/pbidevmode/fabricps-pbip/FabricPS-PBIP.psm1
@@ -760,7 +760,7 @@ Function Import-FabricItems {
                 }
             }
 
-            $partPath = $filePath.Replace($itemPathAbs, "").TrimStart("\").Replace("\", "/")
+            $partPath = $filePath.Replace($itemPathAbs, "").Replace("\", "/").TrimStart("/")
 
             $fileEncodedContent = ($fileContent) ? [Convert]::ToBase64String($fileContent) : ""
             
@@ -982,7 +982,7 @@ Function Import-FabricItem {
             $fileContent = Get-Content -LiteralPath $filePath -AsByteStream -Raw
         }
         
-        $partPath = $filePath.Replace($itemPathAbs, "").TrimStart("\").Replace("\", "/")
+        $partPath = $filePath.Replace($itemPathAbs, "").Replace("\", "/").TrimStart("/")
 
         $fileEncodedContent = ($fileContent) ? [Convert]::ToBase64String($fileContent) : ""
         


### PR DESCRIPTION
Fixes the issue where leading `/` is not stripped when creating the `$partPath` on Unix-based systems (#259)

Merging this would be great :)