### PR TITLE
fix: update foregroupcolor to use default

### DIFF
--- a/pbidevmode/fabricps-pbip/FabricPS-PBIP.psm1
+++ b/pbidevmode/fabricps-pbip/FabricPS-PBIP.psm1
@@ -46,7 +46,7 @@ function Write-Log{
         $foregroundColor = [System.Console]::ForegroundColor
     )
 
-    Write-Host "[$([datetime]::Now.ToString("s"))] $message" -ForegroundColor $foregroundColor
+    Write-Host "[$([datetime]::Now.ToString("s"))] $message"
 }
 
 function Get-FabricAuthToken {


### PR DESCRIPTION
This pull request makes a minor change to the `Write-Log` function in `FabricPS-PBIP.psm1`, simplifying the logging output by removing the use of custom foreground color formatting. The log messages will now display using the default console color. not valid