### PR TITLE
Prevent primary keys from being flagged by "Hide foreign" keys rule

### DIFF
--- a/BestPracticeRules/BPARules.json
+++ b/BestPracticeRules/BPARules.json
@@ -679,7 +679,7 @@
     "Description": "Foreign keys should always be hidden.",
     "Severity": 2,
     "Scope": "DataColumn, CalculatedColumn, CalculatedTableColumn",
-    "Expression": "UsedInRelationships.Any(FromColumn.Name == current.Name and FromCardinality == \"Many\")\n\r\nand\r\n\nIsHidden == false",
+    "Expression": "UsedInRelationships.Any(FromTable.Name == current.Table.Name and FromColumn.Name == current.Name and FromCardinality == \"Many\")\n\r\nand\r\n\nIsHidden == false",
     "FixExpression": "IsHidden = true",
     "CompatibilityLevel": 1200
   },


### PR DESCRIPTION
Fixes #234 

Very noticeable in agentic workloads where primary keys are often hidden without regard for legitimate use-cases.